### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Calendar component for OSX inspired by some free iOS calendar
 	</p>
 </p>
 
-#Description
+# Description
 
 MLCalendarView is a date selector component which is represented as a month calendar. This component extracted from the [ModerLook-OSX](https://github.com/gyetvan-andras/ModernLook-OSX) package for easier standalone use.
 
 The component uses the system Language & Region settings, so it will display the month and day names regarding to the system settings. Also it lays out the days according to the first day of week system setting.
 
-#Usage
+# Usage
 To use the component in your project you need to copy all the files in the MLCalendar group to your project.
 
 MLCalendarView is derived from NSViewController and can be used as any other view. 
@@ -39,8 +39,8 @@ Also, there is a delegate for the calendar, which is used to send a message when
 @end
 ```
 
-#Sample Application
+# Sample Application
 The sample application shows the usage of the component as an NSPopover content.
 
-#License
+# License
 MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
